### PR TITLE
Simplify plugin and allow setting extension

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,23 +1,24 @@
 // match with Gatsby's CSS Modules rule
 const EXTENSION = '.module.css'
 
-const findJsRule = ({ config, rules }) =>
-  config.module.rules.find(({ test }) => test.source === rules.js().test.source)
 
 exports.onCreateWebpackConfig = (
   { actions, getConfig, rules },
   pluginOptions
 ) => {
-  const config = getConfig()
-
-  const jsRule = findJsRule({ config, rules })
-  const astroturfJsLoader = {
-    loader: 'astroturf/loader',
-    options: Object.assign({}, pluginOptions, {
-      extension: EXTENSION,
-    }),
-  }
-  jsRule.use.push(astroturfJsLoader)
-
-  actions.replaceWebpackConfig(config)
+  actions.setWebpackConfig({
+    module: {
+      rules: [
+        {
+          test: /\.jsx?$/,
+          use: [
+            {
+              loader: 'astroturf/loader',
+              options: Object.assign({ extension: EXTENSION }, pluginOptions),
+            },
+          ],
+        },
+      ],
+    },
+  });
 }


### PR DESCRIPTION
It's enough to add a new js test without extending the existing one Also changed the merge order so a user can override the extension they want to use for use with Sass or Less