### PR TITLE
Add .ts and .tsx support

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,7 +10,7 @@ exports.onCreateWebpackConfig = (
     module: {
       rules: [
         {
-          test: /\.jsx?$/,
+          test: /\.(j|t)sx?$/,
           use: [
             {
               loader: 'astroturf/loader',


### PR DESCRIPTION
I tried adding this to a new typescript project and ran into the error `Error: css template literal evaluated at runtime!`. This seems to fix it.

(thanks to hint about loader issues at https://github.com/4Catalyzer/astroturf/issues/29)