### PR TITLE
fix: support typescript

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,15 +3,30 @@ const EXTENSION = '.module.css'
 
 
 exports.onCreateWebpackConfig = (
-  { actions },
+  { actions, loaders },
   pluginOptions
 ) => {
+  const jsLoader = loaders.js()
+  if (!jsLoader) {
+    return;
+  }
+  
   actions.setWebpackConfig({
     module: {
       rules: [
         {
-          test: /\.(j|t)sx?$/,
+          test: /\.jsx?$/,
           use: [
+            {
+              loader: 'astroturf/loader',
+              options: Object.assign({ extension: EXTENSION }, pluginOptions),
+            },
+          ],
+        },
+        {
+          test: /\.tsx?$/,
+          use: [
+            loaders.js(),
             {
               loader: 'astroturf/loader',
               options: Object.assign({ extension: EXTENSION }, pluginOptions),


### PR DESCRIPTION
Use the jsLoader before we use the astroturf loader for .ts/.tsx files.

This fixes issue #4 in my testing.
You must also explicitly include the default `gatsby-plugin-typescript` plugin before the `gatsby-plugin-astroturf` in your `gatsby-config.js`

```js
`gatsby-plugin-typescript`,
`gatsby-plugin-postcss`,
{
  resolve: `gatsby-plugin-astroturf`,
  options: {
    enableDynamicInterpolations: true,
  }
},
```